### PR TITLE
ref: Only write or diff if lines changed

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -17,6 +17,10 @@ pub fn process(
     check: bool,
     output_color: OutputColor,
 ) -> Result<bool, std::io::Error> {
+    if new_lines == old_lines {
+        return Ok(true);
+    }
+
     if !check {
         write_file(file_path, new_lines)?;
         return Ok(true);


### PR DESCRIPTION
Adds an early stop to only write the file in format if the lines are not perfectly equal.
Rationale: Treeformat or other formatters expect formatters to only write / touch the file if something changed.

This also reduced overhead in check, as the diff is only calculated when the lines are not identical.